### PR TITLE
Bi processing disable campaigns

### DIFF
--- a/src/batch/airflow/bi/clean_and_compute_disabled.sql
+++ b/src/batch/airflow/bi/clean_and_compute_disabled.sql
@@ -1,0 +1,30 @@
+-- Clean all "disabled tags"
+UPDATE bi.campaign_river SET "disabled" = NULL;
+
+-- Add the tag disabled to campaigns with GPS problems. They are identified when the number of  
+-- trash is 8 times below the number of different trash locations
+WITH table_summary AS (
+    WITH grouped_trash AS (
+        SELECT 
+            id_ref_campaign_fk, 
+            the_geom, 
+            count(*) AS num, 
+            MAX("time") AS time2 
+        FROM bi.trash
+        GROUP BY id_ref_campaign_fk, the_geom
+    )
+    SELECT 
+        id_ref_campaign_fk, 
+        count(*) AS "num different locations", 
+        sum(num) AS "num trash", 
+        max(time2) AS "time" 
+    FROM grouped_trash 
+    GROUP BY id_ref_campaign_fk
+)
+UPDATE bi.campaign_river cr 
+SET "disabled" = TRUE
+WHERE cr.id_ref_campaign_fk IN (
+    SELECT id_ref_campaign_fk 
+    FROM table_summary ts 
+    WHERE (ts."num trash" > ts."num different locations" * 8)
+)

--- a/src/batch/airflow/bi/compute_bi_temp_campaign_river.sql
+++ b/src/batch/airflow/bi/compute_bi_temp_campaign_river.sql
@@ -39,6 +39,37 @@ FROM
 
 ORDER BY id_ref_campaign_fk, id_ref_river_fk, st_length(the_geom) DESC;
 
+-- Add the tag disabled to campaigns with GPS problems. They are identified when the number of  
+-- trash is 8 times below the number of different trash locations
+WITH table_summary AS (
+    WITH grouped_trash AS (
+        SELECT 
+            id_ref_campaign_fk, 
+            the_geom, 
+            count(*) AS num, 
+            -- MAX("time") AS time2 
+        FROM bi.trash
+        WHERE id_ref_campaign_fk IN (
+            SELECT campaign_id FROM bi_temp.pipeline_to_compute
+        )
+        GROUP BY id_ref_campaign_fk, the_geom
+
+    )
+    SELECT 
+        id_ref_campaign_fk, 
+        count(*) AS "num different locations", 
+        sum(num) AS "num trash", 
+        -- MAX(time2) AS "time" 
+    FROM grouped_trash 
+    GROUP BY id_ref_campaign_fk
+)
+UPDATE bi_temp.campaign_river cr 
+SET "disabled" = TRUE
+WHERE cr.id_ref_campaign_fk IN (
+    SELECT id_ref_campaign_fk 
+    FROM table_summary ts 
+    WHERE (ts."num trash" > ts."num different locations" * 8)
+)
 
 DROP INDEX IF EXISTS bi_temp.campaign_river_the_geom;
 

--- a/src/batch/airflow/bi/compute_bi_temp_campaign_river.sql
+++ b/src/batch/airflow/bi/compute_bi_temp_campaign_river.sql
@@ -39,37 +39,6 @@ FROM
 
 ORDER BY id_ref_campaign_fk, id_ref_river_fk, st_length(the_geom) DESC;
 
--- Add the tag disabled to campaigns with GPS problems. They are identified when the number of  
--- trash is 8 times below the number of different trash locations
-WITH table_summary AS (
-    WITH grouped_trash AS (
-        SELECT 
-            id_ref_campaign_fk, 
-            the_geom, 
-            count(*) AS num, 
-            -- MAX("time") AS time2 
-        FROM bi.trash
-        WHERE id_ref_campaign_fk IN (
-            SELECT campaign_id FROM bi_temp.pipeline_to_compute
-        )
-        GROUP BY id_ref_campaign_fk, the_geom
-
-    )
-    SELECT 
-        id_ref_campaign_fk, 
-        count(*) AS "num different locations", 
-        sum(num) AS "num trash", 
-        -- MAX(time2) AS "time" 
-    FROM grouped_trash 
-    GROUP BY id_ref_campaign_fk
-)
-UPDATE bi_temp.campaign_river cr 
-SET "disabled" = TRUE
-WHERE cr.id_ref_campaign_fk IN (
-    SELECT id_ref_campaign_fk 
-    FROM table_summary ts 
-    WHERE (ts."num trash" > ts."num different locations" * 8)
-)
 
 DROP INDEX IF EXISTS bi_temp.campaign_river_the_geom;
 


### PR DESCRIPTION
- Adding SQL statements in `update_bi_tables.sql`, to compute the disabled field
- Adding a SQL script to just recompute all 'disabled' outside of the normal bi_processing standard process (not used in production) 
